### PR TITLE
feat: set process.platform to browser

### DIFF
--- a/nodelibs/deno/process.ts
+++ b/nodelibs/deno/process.ts
@@ -171,14 +171,14 @@ export const process = {
  * @example `import { argv } from './std/node/process.ts'; console.log(argv)`
  */
 // Proxy delegates --allow-env and --allow-read to request time, even for exports
-export let argv;
+export let argv: any;
 
 /**
  * https://nodejs.org/api/process.html#process_process_env
  * @example `import { env } from './std/node/process.ts'; console.log(env)`
  */
 // Proxy delegates --allow-env and --allow-read to request time, even for exports
-export let env;
+export let env: any;
 
 // import process from './std/node/process.ts'
 export default process;

--- a/src-browser/process.js
+++ b/src-browser/process.js
@@ -1,4 +1,5 @@
 import process from '../node_modules/process/browser.js';
+process.platform = 'browser';
 export default process;
 export var addListener = process.addListener;
 export var argv = process.argv;
@@ -21,3 +22,4 @@ export var title = process.title;
 export var umask = process.umask;
 export var version = process.version;
 export var versions = process.versions;
+export var platform = 'browser';


### PR DESCRIPTION
I don't know why Browserify never did this, but it seems sensible to me.

Fixes https://github.com/jspm/jspm-core/issues/7.