### PR TITLE
feat: worker_threads

### DIFF
--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -29,6 +29,7 @@ class _Worker extends Worker {
     if (options == null) options = { type: 'module' };
     else if (typeof options === 'object') options.type = 'module';
     super(specifier, options);
+    EventEmitter.call(this);
     this.addEventListener('error', (event) => this.emit('error', event.error || event.message));
     this.addEventListener('messageerror', (event) => this.emit('messageerror', event.data));
     this.addEventListener('message', (event) => this.emit('message', event.data));

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -97,9 +97,30 @@ export function setEnvironmentData(key: any, value: any) {
 export const markAsUntransferable = () => unimplemented('markAsUntransferable');
 export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
 export const receiveMessageOnPort = () => unimplemented('receiveMessageOnPort');
+export const MessagePort = globalThis.MessagePort;
+export const MessageChannel = globalThis.MessageChannel;
+export const BroadcastChannel = globalThis.BroadcastChannel;
+export const SHARE_ENV = Symbol.for('nodejs.worker_threads.SHARE_ENV');
 export {
   _Worker as Worker,
   parentPort,
   threadId,
   workerData,
+}
+
+export default {
+  markAsUntransferable,
+  moveMessagePortToContext,
+  receiveMessageOnPort,
+  MessagePort,
+  MessageChannel,
+  BroadcastChannel,
+  Worker: _Worker,
+  getEnvironmentData,
+  setEnvironmentData,
+  SHARE_ENV,
+  threadId,
+  workerData,
+  resourceLimits,
+  parentPort,
 }

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -96,6 +96,7 @@ export function setEnvironmentData(key: any, value: any) {
 
 export const markAsUntransferable = () => unimplemented('markAsUntransferable');
 export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
+export const receiveMessageOnPort = () => unimplemented('receiveMessageOnPort');
 export {
   _Worker as Worker,
   parentPort,

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -91,7 +91,7 @@ if (!isMainThread) {
   }));
   parentPort = self as ParentPort;
   Object.assign(Object.getPrototypeOf(parentPort), EventEmitter.prototype);
-  Object.call(EventEmitter.prototype, parentPort);
+  EventEmitter.call(parentPort);
   parentPort.addEventListener('message', (event: MessageEvent) => parentPort!.emit('message', event.data));
   parentPort.addEventListener('messageerror', (event: MessageEvent) => parentPort!.emit('messageerror', event.data));
 }

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -1,5 +1,6 @@
 /// <reference lib="webworker"/>
 
+import { resolve, toFileUrl } from "https://deno.land/std@0.105.0/path/mod.ts";
 import { EventEmitter } from 'https://deno.land/std@0.105.0/node/events.ts';
 
 function unimplemented(name: string) {
@@ -69,7 +70,7 @@ class _Worker extends Worker {
   private readonly emitter = new EventEmitter();
 
   constructor(specifier: URL | string, options?: _WorkerOptions) {
-    super(specifier, {
+    super(typeof specifier === 'string' ? toFileUrl(resolve(specifier)) : specifier, {
       ...(options || {}),
       type: 'module',
       // unstable

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -123,4 +123,5 @@ export default {
   workerData,
   resourceLimits,
   parentPort,
+  isMainThread,
 }

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker"/>
 
-import { resolve, toFileUrl } from "https://deno.land/std@0.105.0/path/mod.ts";
+import { resolve, toFileUrl } from 'https://deno.land/std@0.105.0/path/mod.ts';
 import { EventEmitter } from 'https://deno.land/std@0.105.0/node/events.ts';
 
 function unimplemented(name: string) {

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -8,8 +8,8 @@ function unimplemented(name: string) {
   );
 }
 
+const environmentData = new Map();
 let threads = 0;
-let environmentData = new Map();
 
 interface _WorkerOptions extends WorkerOptions {
   workerData?: any;

--- a/nodelibs/deno/worker_threads.ts
+++ b/nodelibs/deno/worker_threads.ts
@@ -1,0 +1,104 @@
+/// <reference lib="webworker"/>
+
+import { EventEmitter } from 'https://deno.land/std@0.105.0/node/events.ts';
+
+function unimplemented(name: string) {
+  throw new Error(
+    `Node.js worker_threads ${name} is not currently supported by JSPM core in Deno`,
+  );
+}
+
+let threads = 0;
+let environmentData = new Map();
+
+interface _WorkerOptions extends WorkerOptions {
+  workerData?: any;
+  resourceLimits?: {
+    maxYoungGenerationSizeMb?: number;
+    maxOldGenerationSizeMb?: number;
+    codeRangeSizeMb?: number;
+    stackSizeMb?: number;
+  };
+}
+interface _Worker extends Worker, EventEmitter {}
+class _Worker extends Worker {
+  public threadId: number;
+  public resourceLimits: Required<NonNullable<_WorkerOptions['resourceLimits']>>; 
+
+  constructor(specifier: URL | string, options?: _WorkerOptions) {
+    if (options == null) options = { type: 'module' };
+    else if (typeof options === 'object') options.type = 'module';
+    super(specifier, options);
+    this.addEventListener('error', (event) => this.emit('error', event.error || event.message));
+    this.addEventListener('messageerror', (event) => this.emit('messageerror', event.data));
+    this.addEventListener('message', (event) => this.emit('message', event.data));
+    this.postMessage({
+      environmentData,
+      threadId: (this.threadId = ++threads),
+      workerData: options.workerData,
+    });
+    this.resourceLimits = {
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    };
+    this.emit('online');
+  }
+
+  terminate() {
+    super.terminate();
+    this.emit('exit', 0);
+  }
+
+  getHeapSnapshot = () => unimplemented('Worker#getHeapsnapshot');
+  // fake performance
+  performance = globalThis.performance;
+}
+Object.assign(Worker.prototype, EventEmitter.prototype)
+
+export const isMainThread = typeof WorkerGlobalScope === 'undefined' || self instanceof WorkerGlobalScope === false;
+// fake resourceLimits
+export const resourceLimits = isMainThread ? {} : {
+  maxYoungGenerationSizeMb: 48,
+  maxOldGenerationSizeMb: 2048,
+  codeRangeSizeMb: 0,
+  stackSizeMb: 4,
+};
+
+let threadId = 0;
+let workerData = null;
+let parentPort: (WorkerGlobalScope & typeof globalThis & EventEmitter) | null = null;
+
+if (!isMainThread) {
+  ({ threadId, workerData, environmentData } = await new Promise((resolve) =>
+    self.addEventListener('message', (event: MessageEvent) => resolve(event.data), {
+      once: true,
+    }),
+  ));
+  parentPort = self as WorkerGlobalScope & typeof globalThis & EventEmitter;
+  Object.assign(Object.getPrototypeOf(parentPort), EventEmitter.prototype);
+  parentPort.addEventListener('message', (event: MessageEvent) => parentPort!.emit('message', event.data));
+  parentPort.addEventListener('messageerror', (event: MessageEvent) => parentPort!.emit('messageerror', event.data));
+}
+
+export function getEnvironmentData(key: any) {
+  return environmentData.get(key);
+}
+
+export function setEnvironmentData(key: any, value: any) {
+  if (value === undefined) {
+    environmentData.delete(key);
+  } else {
+    environmentData.set(key, value);
+  }
+}
+
+export const markAsUntransferable = () => unimplemented('markAsUntransferable');
+export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
+export {
+  _Worker as Worker,
+  parentPort,
+  threadId,
+  workerData,
+}

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -65,7 +65,6 @@ if (!isMainThread) {
   Object.assign(Object.getPrototypeOf(parentPort), EventEmitter.prototype);
   parentPort.addEventListener('message', (event) => parentPort.emit('message', event.data));
   parentPort.addEventListener('messageerror', (event) => parentPort.emit('messageerror', event.data));
-  parentPort.addEventListener('close', () => parentPort.emit('close'));
 }
 
 export function getEnvironmentData(key) {

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -81,4 +81,5 @@ export function setEnvironmentData(key, value) {
 
 export const markAsUntransferable = () => unimplemented('markAsUntransferable');
 export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
+export const receiveMessageOnPort = () => unimplemented('receiveMessageOnPort');
 export { parentPort, threadId, workerData };

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -95,7 +95,7 @@ export default {
   MessagePort,
   MessageChannel,
   BroadcastChannel,
-  Worker: _Worker,
+  Worker,
   getEnvironmentData,
   setEnvironmentData,
   SHARE_ENV,
@@ -103,4 +103,5 @@ export default {
   workerData,
   resourceLimits,
   parentPort,
+  isMainThread,
 }

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -61,7 +61,7 @@ if (!isMainThread) {
   }));
   parentPort = self;
   Object.assign(Object.getPrototypeOf(parentPort), EventEmitter.prototype);
-  Object.call(EventEmitter.prototype, parentPort);
+  EventEmitter.call(parentPort);
   parentPort.addEventListener('message', (event) => parentPort.emit('message', event.data));
   parentPort.addEventListener('messageerror', (event) => parentPort.emit('messageerror', event.data));
 }

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -6,8 +6,8 @@ function unimplemented(name) {
   );
 }
 
+const environmentData = new Map();
 let threads = 0;
-let environmentData = new Map();
 
 export class Worker extends globalThis.Worker {
   constructor(specifier, options) {

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -82,4 +82,25 @@ export function setEnvironmentData(key, value) {
 export const markAsUntransferable = () => unimplemented('markAsUntransferable');
 export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
 export const receiveMessageOnPort = () => unimplemented('receiveMessageOnPort');
+export const MessagePort = globalThis.MessagePort;
+export const MessageChannel = globalThis.MessageChannel;
+export const BroadcastChannel = globalThis.BroadcastChannel;
+export const SHARE_ENV = Symbol.for('nodejs.worker_threads.SHARE_ENV');
 export { parentPort, threadId, workerData };
+
+export default {
+  markAsUntransferable,
+  moveMessagePortToContext,
+  receiveMessageOnPort,
+  MessagePort,
+  MessageChannel,
+  BroadcastChannel,
+  Worker: _Worker,
+  getEnvironmentData,
+  setEnvironmentData,
+  SHARE_ENV,
+  threadId,
+  workerData,
+  resourceLimits,
+  parentPort,
+}

--- a/src-browser/worker_threads.js
+++ b/src-browser/worker_threads.js
@@ -1,0 +1,85 @@
+import { EventEmitter } from 'events';
+
+function unimplemented(name) {
+  throw new Error(
+    `Node.js worker_threads ${name} is not currently supported by JSPM core in the browser`,
+  );
+}
+
+let threads = 0;
+let environmentData = new Map();
+
+export class Worker extends globalThis.Worker {
+  constructor(specifier, options) {
+    if (options == null) options = { type: 'module' };
+    else if (typeof options === 'object') options.type = 'module';
+    super(specifier, options);
+    this.addEventListener('error', (event) => this.emit('error', event.error || event.message));
+    this.addEventListener('messageerror', (event) => this.emit('messageerror', event.data));
+    this.addEventListener('message', (event) => this.emit('message', event.data));
+    this.postMessage({
+      environmentData,
+      threadId: (this.threadId = ++threads),
+      workerData: options.workerData,
+    });
+    this.resourceLimits = {
+      maxYoungGenerationSizeMb: -1,
+      maxOldGenerationSizeMb: -1,
+      codeRangeSizeMb: -1,
+      stackSizeMb: 4,
+    };
+    this.emit('online');
+  }
+
+  terminate() {
+    super.terminate();
+    this.emit('exit', 0);
+  }
+
+  getHeapSnapshot = () => unimplemented('Worker#getHeapsnapshot');
+  // fake performance
+  performance = globalThis.performance;
+}
+Object.assign(Worker.prototype, EventEmitter.prototype)
+
+export const isMainThread = typeof WorkerGlobalScope === 'undefined' || self instanceof WorkerGlobalScope === false;
+// fake resourceLimits
+export const resourceLimits = isMainThread ? {} : {
+  maxYoungGenerationSizeMb: 48,
+  maxOldGenerationSizeMb: 2048,
+  codeRangeSizeMb: 0,
+  stackSizeMb: 4,
+};
+
+let threadId = 0;
+let workerData = null;
+let parentPort = null;
+
+if (!isMainThread) {
+  ({ threadId, workerData, environmentData } = await new Promise((resolve) =>
+    self.addEventListener('message', (event) => resolve(event.data), {
+      once: true,
+    }),
+  ));
+  parentPort = self;
+  Object.assign(Object.getPrototypeOf(parentPort), EventEmitter.prototype);
+  parentPort.addEventListener('message', (event) => parentPort.emit('message', event.data));
+  parentPort.addEventListener('messageerror', (event) => parentPort.emit('messageerror', event.data));
+  parentPort.addEventListener('close', () => parentPort.emit('close'));
+}
+
+export function getEnvironmentData(key) {
+  return environmentData.get(key);
+}
+
+export function setEnvironmentData(key, value) {
+  if (value === undefined) {
+    environmentData.delete(key);
+  } else {
+    environmentData.set(key, value);
+  }
+}
+
+export const markAsUntransferable = () => unimplemented('markAsUntransferable');
+export const moveMessagePortToContext = () => unimplemented('moveMessagePortToContext');
+export { parentPort, threadId, workerData };

--- a/test/test.html
+++ b/test/test.html
@@ -94,7 +94,7 @@
     console.error('Invalid exports')
   } else if (Object.keys(webStream).length < 2)
     console.error('Invalid exports.');
-  else if (Object.keys(workerThreads).length < 2) {
+  else if (Object.keys(workerThreads).length < 15) {
     console.error('Invalid exports')
   }
   else {

--- a/test/test.html
+++ b/test/test.html
@@ -94,7 +94,7 @@
     console.error('Invalid exports')
   } else if (Object.keys(webStream).length < 2)
     console.error('Invalid exports.');
-  else if (Object.keys(workerThreads).length < 15) {
+  else if (Object.keys(workerThreads).length < 16) {
     console.error('Invalid exports')
   }
   else {

--- a/test/test.html
+++ b/test/test.html
@@ -34,6 +34,7 @@
   import * as performance from '../nodelibs/browser/perf_hooks.js'
   import * as diagnostics_channel from '../nodelibs/browser/diagnostics_channel.js'
   import * as webStream from '../nodelibs/browser/stream/web.js';
+  import * as workerThreads from '../nodelibs/browser/worker_threads.js'
 
   if (Object.keys(assert).length < 2)
     console.error('Invalid exports.');
@@ -93,6 +94,9 @@
     console.error('Invalid exports')
   } else if (Object.keys(webStream).length < 2)
     console.error('Invalid exports.');
+  else if (Object.keys(workerThreads).length < 2) {
+    console.error('Invalid exports')
+  }
   else {
     console.log('OK');
     fetch('/done');


### PR DESCRIPTION
Fixes https://github.com/jspm/jspm-core/issues/8.

Except types, normally `deno/worker_threads.ts` is the same as `src-browser/worker_threads.js`.
For Deno, I can make a PR (in deno_std) for `worker_threads`, and when there is a release, replace the current code with an import?