### PR TITLE
fix: Text{Encoder|Decoder} interfaces on util

### DIFF
--- a/nodelibs/browser/util.js
+++ b/nodelibs/browser/util.js
@@ -29,7 +29,7 @@ var log = X.log;
 var promisify = X.promisify;
 var types = X.types;
 
-const TextEncoder = self.TextEncoder;
-const TextDecoder = self.TextDecoder;
+const TextEncoder = X.TextEncoder = self.TextEncoder;
+const TextDecoder = X.TextDecoder = self.TextDecoder;
 
 export { TextDecoder, TextEncoder, _extend, callbackify, debuglog, deprecate, format, inherits, inspect, isArray, isBoolean, isBuffer, isDate, isError, isFunction, isNull, isNullOrUndefined, isNumber, isObject, isPrimitive, isRegExp, isString, isSymbol, isUndefined, log, promisify, types };

--- a/src-browser/util.js
+++ b/src-browser/util.js
@@ -26,5 +26,5 @@ export var log = util.log;
 export var promisify = util.promisify;
 export var types = util.types;
 
-export const TextEncoder = self.TextEncoder;
-export const TextDecoder = self.TextDecoder;
+export const TextEncoder = util.TextEncoder = self.TextEncoder;
+export const TextDecoder = util.TextDecoder = self.TextDecoder;


### PR DESCRIPTION
Fixes up the TextEncoder / TextDecoder exports. Resolves the current issue in https://github.com/jspm/project/issues/134.