### PR TITLE
Remove process.versions.node for node detection

### DIFF
--- a/src-browser/process.js
+++ b/src-browser/process.js
@@ -76,7 +76,7 @@ export var env = {
 export var argv = ['/usr/bin/node'];
 export var execArgv = [];
 export var version = 'v16.8.0';
-export var versions = { node: '16.8.0' };
+export var versions = {};
 
 export var emitWarning = function(message, type) {
   console.warn((type ? (type + ': ') : '') + message);


### PR DESCRIPTION
Some libraries do a Node.js detection like `if (process.versions.node)`. For this reason we shouldn't be polyfilling this version.

@Mesteery I think at some point it could be worth considering splitting the Node.js libs into two classes by having two condition combinations - `"browser"` or `"browser" + "node"`, where `"browser" + "node"` effectively does something more like web containers in fully trying to virtualize Node.js in a browser as an environment condition. It would be interesting to see how far we could get with workflows around that. For process this would effectively split it into two - `process-browser.js` and `process-browser-node.js`.