### PR TITLE
add url parse export

### DIFF
--- a/nodelibs/browser/url.js
+++ b/nodelibs/browser/url.js
@@ -685,6 +685,7 @@ var Url = h.Url;
 var format = h.format;
 var resolve = h.resolve;
 var resolveObject = h.resolveObject;
+var parse = h.parse;
 
 const _URL = h.URL;
 
@@ -801,4 +802,4 @@ function pathToFileURL(filepath) {
   return outURL;
 }
 
-export { _URL as URL, Url, h as default, fileURLToPath, format, pathToFileURL, resolve, resolveObject };
+export { _URL as URL, Url, h as default, fileURLToPath, format, parse, pathToFileURL, resolve, resolveObject };

--- a/src-browser/url.js
+++ b/src-browser/url.js
@@ -34,6 +34,7 @@ export var Url = url.Url;
 export var format = url.format;
 export var resolve = url.resolve;
 export var resolveObject = url.resolveObject;
+export var parse = url.parse;
 
 const _URL = url.URL;
 export { _URL as URL }


### PR DESCRIPTION
This adds the URL `parse` export which was missing.