### PR TITLE
feat: use node: prefix for node imports

### DIFF
--- a/nodelibs/node/_http_agent.js
+++ b/nodelibs/node/_http_agent.js
@@ -1,2 +1,2 @@
-export { default } from '_http_agent';
-export * from '_http_agent';
+export { default } from 'node:_http_agent';
+export * from 'node:_http_agent';

--- a/nodelibs/node/_http_client.js
+++ b/nodelibs/node/_http_client.js
@@ -1,2 +1,2 @@
-export { default } from '_http_client';
-export * from '_http_client';
+export { default } from 'node:_http_client';
+export * from 'node:_http_client';

--- a/nodelibs/node/_http_common.js
+++ b/nodelibs/node/_http_common.js
@@ -1,2 +1,2 @@
-export { default } from '_http_common';
-export * from '_http_common';
+export { default } from 'node:_http_common';
+export * from 'node:_http_common';

--- a/nodelibs/node/_http_incoming.js
+++ b/nodelibs/node/_http_incoming.js
@@ -1,2 +1,2 @@
-export { default } from '_http_incoming';
-export * from '_http_incoming';
+export { default } from 'node:_http_incoming';
+export * from 'node:_http_incoming';

--- a/nodelibs/node/_http_outgoing.js
+++ b/nodelibs/node/_http_outgoing.js
@@ -1,2 +1,2 @@
-export { default } from '_http_outgoing';
-export * from '_http_outgoing';
+export { default } from 'node:_http_outgoing';
+export * from 'node:_http_outgoing';

--- a/nodelibs/node/_http_server.js
+++ b/nodelibs/node/_http_server.js
@@ -1,2 +1,2 @@
-export { default } from '_http_server';
-export * from '_http_server';
+export { default } from 'node:_http_server';
+export * from 'node:_http_server';

--- a/nodelibs/node/_stream_duplex.js
+++ b/nodelibs/node/_stream_duplex.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_duplex';
-export * from '_stream_duplex';
+export { default } from 'node:_stream_duplex';
+export * from 'node:_stream_duplex';

--- a/nodelibs/node/_stream_passthrough.js
+++ b/nodelibs/node/_stream_passthrough.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_passthrough';
-export * from '_stream_passthrough';
+export { default } from 'node:_stream_passthrough';
+export * from 'node:_stream_passthrough';

--- a/nodelibs/node/_stream_readable.js
+++ b/nodelibs/node/_stream_readable.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_readable';
-export * from '_stream_readable';
+export { default } from 'node:_stream_readable';
+export * from 'node:_stream_readable';

--- a/nodelibs/node/_stream_transform.js
+++ b/nodelibs/node/_stream_transform.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_transform';
-export * from '_stream_transform';
+export { default } from 'node:_stream_transform';
+export * from 'node:_stream_transform';

--- a/nodelibs/node/_stream_wrap.js
+++ b/nodelibs/node/_stream_wrap.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_wrap';
-export * from '_stream_wrap';
+export { default } from 'node:_stream_wrap';
+export * from 'node:_stream_wrap';

--- a/nodelibs/node/_stream_writable.js
+++ b/nodelibs/node/_stream_writable.js
@@ -1,2 +1,2 @@
-export { default } from '_stream_writable';
-export * from '_stream_writable';
+export { default } from 'node:_stream_writable';
+export * from 'node:_stream_writable';

--- a/nodelibs/node/_tls_common.js
+++ b/nodelibs/node/_tls_common.js
@@ -1,2 +1,2 @@
-export { default } from '_tls_common';
-export * from '_tls_common';
+export { default } from 'node:_tls_common';
+export * from 'node:_tls_common';

--- a/nodelibs/node/_tls_wrap.js
+++ b/nodelibs/node/_tls_wrap.js
@@ -1,2 +1,2 @@
-export { default } from '_tls_wrap';
-export * from '_tls_wrap';
+export { default } from 'node:_tls_wrap';
+export * from 'node:_tls_wrap';

--- a/nodelibs/node/assert.js
+++ b/nodelibs/node/assert.js
@@ -1,2 +1,2 @@
-export { default } from 'assert';
-export * from 'assert';
+export { default } from 'node:assert';
+export * from 'node:assert';

--- a/nodelibs/node/assert/strict.js
+++ b/nodelibs/node/assert/strict.js
@@ -1,2 +1,2 @@
-export { default } from 'assert/strict';
-export * from 'assert/strict';
+export { default } from 'node:assert/strict';
+export * from 'node:assert/strict';

--- a/nodelibs/node/async_hooks.js
+++ b/nodelibs/node/async_hooks.js
@@ -1,2 +1,2 @@
-export { default } from 'async_hooks';
-export * from 'async_hooks';
+export { default } from 'node:async_hooks';
+export * from 'node:async_hooks';

--- a/nodelibs/node/buffer.js
+++ b/nodelibs/node/buffer.js
@@ -1,2 +1,2 @@
-export { default } from 'buffer';
-export * from 'buffer';
+export { default } from 'node:buffer';
+export * from 'node:buffer';

--- a/nodelibs/node/child_process.js
+++ b/nodelibs/node/child_process.js
@@ -1,2 +1,2 @@
-export { default } from 'child_process';
-export * from 'child_process';
+export { default } from 'node:child_process';
+export * from 'node:child_process';

--- a/nodelibs/node/cluster.js
+++ b/nodelibs/node/cluster.js
@@ -1,2 +1,2 @@
-export { default } from 'cluster';
-export * from 'cluster';
+export { default } from 'node:cluster';
+export * from 'node:cluster';

--- a/nodelibs/node/console.js
+++ b/nodelibs/node/console.js
@@ -1,2 +1,2 @@
-export { default } from 'console';
-export * from 'console';
+export { default } from 'node:console';
+export * from 'node:console';

--- a/nodelibs/node/constants.js
+++ b/nodelibs/node/constants.js
@@ -1,2 +1,2 @@
-export { default } from 'constants';
-export * from 'constants';
+export { default } from 'node:constants';
+export * from 'node:constants';

--- a/nodelibs/node/crypto.js
+++ b/nodelibs/node/crypto.js
@@ -1,2 +1,2 @@
-export { default } from 'crypto';
-export * from 'crypto';
+export { default } from 'node:crypto';
+export * from 'node:crypto';

--- a/nodelibs/node/dgram.js
+++ b/nodelibs/node/dgram.js
@@ -1,2 +1,2 @@
-export { default } from 'dgram';
-export * from 'dgram';
+export { default } from 'node:dgram';
+export * from 'node:dgram';

--- a/nodelibs/node/diagnostics_channel.js
+++ b/nodelibs/node/diagnostics_channel.js
@@ -1,2 +1,2 @@
-export { default } from 'diagnostics_channel';
-export * from 'diagnostics_channel';
+export { default } from 'node:diagnostics_channel';
+export * from 'node:diagnostics_channel';

--- a/nodelibs/node/dns.js
+++ b/nodelibs/node/dns.js
@@ -1,2 +1,2 @@
-export { default } from 'dns';
-export * from 'dns';
+export { default } from 'node:dns';
+export * from 'node:dns';

--- a/nodelibs/node/dns/promises.js
+++ b/nodelibs/node/dns/promises.js
@@ -1,2 +1,2 @@
-export { default } from 'dns/promises';
-export * from 'dns/promises';
+export { default } from 'node:dns/promises';
+export * from 'node:dns/promises';

--- a/nodelibs/node/domain.js
+++ b/nodelibs/node/domain.js
@@ -1,2 +1,2 @@
-export { default } from 'domain';
-export * from 'domain';
+export { default } from 'node:domain';
+export * from 'node:domain';

--- a/nodelibs/node/events.js
+++ b/nodelibs/node/events.js
@@ -1,2 +1,2 @@
-export { default } from 'events';
-export * from 'events';
+export { default } from 'node:events';
+export * from 'node:events';

--- a/nodelibs/node/fs.js
+++ b/nodelibs/node/fs.js
@@ -1,2 +1,2 @@
-export { default } from 'fs';
-export * from 'fs';
+export { default } from 'node:fs';
+export * from 'node:fs';

--- a/nodelibs/node/fs/promises.js
+++ b/nodelibs/node/fs/promises.js
@@ -1,2 +1,2 @@
-export { default } from 'fs/promises';
-export * from 'fs/promises';
+export { default } from 'node:fs/promises';
+export * from 'node:fs/promises';

--- a/nodelibs/node/http.js
+++ b/nodelibs/node/http.js
@@ -1,2 +1,2 @@
-export { default } from 'http';
-export * from 'http';
+export { default } from 'node:http';
+export * from 'node:http';

--- a/nodelibs/node/http2.js
+++ b/nodelibs/node/http2.js
@@ -1,2 +1,2 @@
-export { default } from 'http2';
-export * from 'http2';
+export { default } from 'node:http2';
+export * from 'node:http2';

--- a/nodelibs/node/https.js
+++ b/nodelibs/node/https.js
@@ -1,2 +1,2 @@
-export { default } from 'https';
-export * from 'https';
+export { default } from 'node:https';
+export * from 'node:https';

--- a/nodelibs/node/inspector.js
+++ b/nodelibs/node/inspector.js
@@ -1,2 +1,2 @@
-export { default } from 'inspector';
-export * from 'inspector';
+export { default } from 'node:inspector';
+export * from 'node:inspector';

--- a/nodelibs/node/module.js
+++ b/nodelibs/node/module.js
@@ -1,2 +1,2 @@
-export { default } from 'module';
-export * from 'module';
+export { default } from 'node:module';
+export * from 'node:module';

--- a/nodelibs/node/net.js
+++ b/nodelibs/node/net.js
@@ -1,2 +1,2 @@
-export { default } from 'net';
-export * from 'net';
+export { default } from 'node:net';
+export * from 'node:net';

--- a/nodelibs/node/os.js
+++ b/nodelibs/node/os.js
@@ -1,2 +1,2 @@
-export { default } from 'os';
-export * from 'os';
+export { default } from 'node:os';
+export * from 'node:os';

--- a/nodelibs/node/path.js
+++ b/nodelibs/node/path.js
@@ -1,2 +1,2 @@
-export { default } from 'path';
-export * from 'path';
+export { default } from 'node:path';
+export * from 'node:path';

--- a/nodelibs/node/path/posix.js
+++ b/nodelibs/node/path/posix.js
@@ -1,2 +1,2 @@
-export { default } from 'path/posix';
-export * from 'path/posix';
+export { default } from 'node:path/posix';
+export * from 'node:path/posix';

--- a/nodelibs/node/path/win32.js
+++ b/nodelibs/node/path/win32.js
@@ -1,2 +1,2 @@
-export { default } from 'path/win32';
-export * from 'path/win32';
+export { default } from 'node:path/win32';
+export * from 'node:path/win32';

--- a/nodelibs/node/perf_hooks.js
+++ b/nodelibs/node/perf_hooks.js
@@ -1,2 +1,2 @@
-export { default } from 'perf_hooks';
-export * from 'perf_hooks';
+export { default } from 'node:perf_hooks';
+export * from 'node:perf_hooks';

--- a/nodelibs/node/process-production.js
+++ b/nodelibs/node/process-production.js
@@ -1,4 +1,4 @@
-import process from './process.js';
-export * from './process.js';
+import process from 'node:./process.js';
+export * from 'node:./process.js';
 export default process;
 process.env.NODE_ENV = 'production';

--- a/nodelibs/node/process.js
+++ b/nodelibs/node/process.js
@@ -1,2 +1,2 @@
-export { default } from 'process';
-export * from 'process';
+export { default } from 'node:process';
+export * from 'node:process';

--- a/nodelibs/node/punycode.js
+++ b/nodelibs/node/punycode.js
@@ -1,2 +1,2 @@
-export { default } from 'punycode';
-export * from 'punycode';
+export { default } from 'node:punycode';
+export * from 'node:punycode';

--- a/nodelibs/node/querystring.js
+++ b/nodelibs/node/querystring.js
@@ -1,2 +1,2 @@
-export { default } from 'querystring';
-export * from 'querystring';
+export { default } from 'node:querystring';
+export * from 'node:querystring';

--- a/nodelibs/node/readline.js
+++ b/nodelibs/node/readline.js
@@ -1,2 +1,2 @@
-export { default } from 'readline';
-export * from 'readline';
+export { default } from 'node:readline';
+export * from 'node:readline';

--- a/nodelibs/node/readline/promises.js
+++ b/nodelibs/node/readline/promises.js
@@ -1,2 +1,2 @@
-export { default } from 'readline/promises';
-export * from 'readline/promises';
+export { default } from 'node:readline/promises';
+export * from 'node:readline/promises';

--- a/nodelibs/node/repl.js
+++ b/nodelibs/node/repl.js
@@ -1,2 +1,2 @@
-export { default } from 'repl';
-export * from 'repl';
+export { default } from 'node:repl';
+export * from 'node:repl';

--- a/nodelibs/node/stream.js
+++ b/nodelibs/node/stream.js
@@ -1,2 +1,2 @@
-export { default } from 'stream';
-export * from 'stream';
+export { default } from 'node:stream';
+export * from 'node:stream';

--- a/nodelibs/node/stream/consumers.js
+++ b/nodelibs/node/stream/consumers.js
@@ -1,2 +1,2 @@
-export { default } from 'stream/consumers';
-export * from 'stream/consumers';
+export { default } from 'node:stream/consumers';
+export * from 'node:stream/consumers';

--- a/nodelibs/node/stream/promises.js
+++ b/nodelibs/node/stream/promises.js
@@ -1,2 +1,2 @@
-export { default } from 'stream/promises';
-export * from 'stream/promises';
+export { default } from 'node:stream/promises';
+export * from 'node:stream/promises';

--- a/nodelibs/node/stream/web.js
+++ b/nodelibs/node/stream/web.js
@@ -1,2 +1,2 @@
-export { default } from 'stream/web';
-export * from 'stream/web';
+export { default } from 'node:stream/web';
+export * from 'node:stream/web';

--- a/nodelibs/node/string_decoder.js
+++ b/nodelibs/node/string_decoder.js
@@ -1,2 +1,2 @@
-export { default } from 'string_decoder';
-export * from 'string_decoder';
+export { default } from 'node:string_decoder';
+export * from 'node:string_decoder';

--- a/nodelibs/node/sys.js
+++ b/nodelibs/node/sys.js
@@ -1,2 +1,2 @@
-export { default } from 'sys';
-export * from 'sys';
+export { default } from 'node:sys';
+export * from 'node:sys';

--- a/nodelibs/node/timers.js
+++ b/nodelibs/node/timers.js
@@ -1,2 +1,2 @@
-export { default } from 'timers';
-export * from 'timers';
+export { default } from 'node:timers';
+export * from 'node:timers';

--- a/nodelibs/node/timers/promises.js
+++ b/nodelibs/node/timers/promises.js
@@ -1,2 +1,2 @@
-export { default } from 'timers/promises';
-export * from 'timers/promises';
+export { default } from 'node:timers/promises';
+export * from 'node:timers/promises';

--- a/nodelibs/node/tls.js
+++ b/nodelibs/node/tls.js
@@ -1,2 +1,2 @@
-export { default } from 'tls';
-export * from 'tls';
+export { default } from 'node:tls';
+export * from 'node:tls';

--- a/nodelibs/node/trace_events.js
+++ b/nodelibs/node/trace_events.js
@@ -1,2 +1,2 @@
-export { default } from 'trace_events';
-export * from 'trace_events';
+export { default } from 'node:trace_events';
+export * from 'node:trace_events';

--- a/nodelibs/node/tty.js
+++ b/nodelibs/node/tty.js
@@ -1,2 +1,2 @@
-export { default } from 'tty';
-export * from 'tty';
+export { default } from 'node:tty';
+export * from 'node:tty';

--- a/nodelibs/node/url.js
+++ b/nodelibs/node/url.js
@@ -1,2 +1,2 @@
-export { default } from 'url';
-export * from 'url';
+export { default } from 'node:url';
+export * from 'node:url';

--- a/nodelibs/node/util.js
+++ b/nodelibs/node/util.js
@@ -1,2 +1,2 @@
-export { default } from 'util';
-export * from 'util';
+export { default } from 'node:util';
+export * from 'node:util';

--- a/nodelibs/node/util/types.js
+++ b/nodelibs/node/util/types.js
@@ -1,2 +1,2 @@
-export { default } from 'util/types';
-export * from 'util/types';
+export { default } from 'node:util/types';
+export * from 'node:util/types';

--- a/nodelibs/node/v8.js
+++ b/nodelibs/node/v8.js
@@ -1,2 +1,2 @@
-export { default } from 'v8';
-export * from 'v8';
+export { default } from 'node:v8';
+export * from 'node:v8';

--- a/nodelibs/node/vm.js
+++ b/nodelibs/node/vm.js
@@ -1,2 +1,2 @@
-export { default } from 'vm';
-export * from 'vm';
+export { default } from 'node:vm';
+export * from 'node:vm';

--- a/nodelibs/node/worker_threads.js
+++ b/nodelibs/node/worker_threads.js
@@ -1,2 +1,2 @@
-export { default } from 'worker_threads';
-export * from 'worker_threads';
+export { default } from 'node:worker_threads';
+export * from 'node:worker_threads';

--- a/nodelibs/node/zlib.js
+++ b/nodelibs/node/zlib.js
@@ -1,2 +1,2 @@
-export { default } from 'zlib';
-export * from 'zlib';
+export { default } from 'node:zlib';
+export * from 'node:zlib';


### PR DESCRIPTION
Updates the Node.js core libraries to use `import 'node:process'` style prefixing, ensuring unambiguous maps.