### PR TITLE
Add License Field to `package.json` for Clarity and Compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@jspm/core",
       "version": "2.0.1",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@jspm/plugin-rollup": "github:jspm/rollup-plugin-jspm#main",
         "@wasmer/wasi": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -85,5 +85,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jspm/jspm-core.git"
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
I've noticed that while you have a LICENSE file, the license isn't specified in the `package.json`. I'd like to propose a small yet significant enhancement by adding the license information to your `package.json`. This change offers several benefits:

- **Immediate Visibility**: It provides instant clarity regarding the licensing terms right from the package metadata, which is beneficial for users and developers exploring your package.
- **Tool Compatibility**: Automated tools and services, like npm and GitHub, rely on the `package.json` file to detect and display license information. This enhancement ensures your project is correctly recognized in various ecosystems.
- **Community Best Practices**: Including the license in `package.json` is a common practice in the open-source community. It helps in maintaining consistency with these standards.
- **Legal Clarity**: Specifying the license in both the `package.json` and the LICENSE file eliminates ambiguity about your project's licensing terms, which is crucial for legal clarity.
